### PR TITLE
Add edit unit admin functionality

### DIFF
--- a/src/actions/admin/units.ts
+++ b/src/actions/admin/units.ts
@@ -4,6 +4,7 @@ import { units } from "@/db/schema";
 import { unitFormSchema } from "@/lib/validations/unit";
 import { adminClient } from "@/lib/safe-action";
 import { eq, asc, sql, and } from "drizzle-orm";
+import { z } from "zod";
 
 export const createUnitAction = adminClient
   .schema(unitFormSchema)
@@ -47,3 +48,37 @@ export async function getUnitsForCourse(courseId: number) {
     .where(eq(units.courseId, courseId))
     .orderBy(asc(units.position));
 }
+
+// update an existing unit
+export const updateUnitAction = adminClient
+  // extend schema to require ID of the unit to update
+  .schema(
+    unitFormSchema.extend({
+      id: z.number(),
+    })
+  )
+  .action(async ({ parsedInput }) => {
+    const { id, title, courseId } = parsedInput;
+
+    // check if another unit with same title exists
+    const existing = await db
+      .select()
+      .from(units)
+      .where(and(eq(units.title, title), eq(units.courseId, courseId)));
+
+    // if a duplicate exists AND it's not this unit, return an error
+    if (existing.length > 0 && existing[0].id !== id) {
+      return {
+        success: false,
+        serverError: "A unit with this title already exists.",
+      };
+    }
+
+    // update the unit's title
+    await db
+      .update(units)
+      .set({ title })
+      .where(eq(units.id, id));
+
+    return { success: true };
+  });

--- a/src/app/admin/courses/[courseId]/units/edit/[unitId]/EditUnitForm.tsx
+++ b/src/app/admin/courses/[courseId]/units/edit/[unitId]/EditUnitForm.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { useTransition, useState } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { unitFormSchema } from "@/lib/validations/unit";
+import { updateUnitAction } from "@/actions/admin/units";
+import { z } from "zod";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+
+export default function EditUnitForm({ unit }: { unit: any }) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();   // pending UI state
+  const [serverError, setServerError] = useState("");     // holds backend validation error
+
+  // initialize form with Zod validation and unit's default values
+  const form = useForm<z.infer<typeof unitFormSchema>>({
+    resolver: zodResolver(unitFormSchema),
+    defaultValues: {
+      title: unit.title,
+      courseId: unit.courseId,
+    },
+  });
+
+  // handle form submission
+  const onSubmit = (values: z.infer<typeof unitFormSchema>) => {
+    setServerError("");
+
+    // wrap the server action in a transition for smoother UI
+    startTransition(async () => {
+      const result = await updateUnitAction({
+        id: unit.id,     // include the unit ID for updating
+        ...values,
+      });
+
+      // show errors
+      if (result?.serverError) {
+        setServerError(result.serverError);
+        return;
+      }
+
+      // show success message
+      toast.success("Unit updated successfully!");
+
+      // redirect to the course page after saving
+      router.push(`/admin/courses/${unit.courseId}`);
+    });
+  };
+
+  return (
+    <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6 max-w-xl">
+      {/* show server side validation or duplicate title errors */}
+      {serverError && (
+        <p className="text-red-500 text-sm">{serverError}</p>
+      )}
+
+      {/* input: Unit title */}
+      <div>
+        <label className="block font-medium mb-1">Unit Title</label>
+        <Input
+          placeholder="Unit title"
+          disabled={isPending}
+          {...form.register("title")}
+        />
+        {form.formState.errors.title && (
+          <p className="text-red-500 text-sm mt-1">
+            {form.formState.errors.title.message}
+          </p>
+        )}
+      </div>
+
+      {/* submit button */}
+      <Button type="submit" disabled={isPending}>
+        {isPending ? "Saving..." : "Save Changes"}
+      </Button>
+    </form>
+  );
+}

--- a/src/app/admin/courses/[courseId]/units/edit/[unitId]/page.tsx
+++ b/src/app/admin/courses/[courseId]/units/edit/[unitId]/page.tsx
@@ -1,9 +1,39 @@
-import type { CourseIdPageProps } from '@/lib/types'
+import { db } from "@/db";
+import { units } from "@/db/schema";
+import { eq } from "drizzle-orm";
+import EditUnitForm from "./EditUnitForm";
 
-export default async function page({ params }: CourseIdPageProps) {
-  const { courseId } = await params; 
-  const id = Number(courseId);
+export default async function EditUnitPage({
+  params,
+}: {
+  params: Promise<{ courseId: string; unitId: string }>;
+}) {
+  // must await params (Next.js rule)
+  const { courseId, unitId } = await params;
+
+  // convert route params to numbers
+  const cid = Number(courseId);
+  const uid = Number(unitId);
+
+  // validation for bad URLs or IDs
+  if (isNaN(cid) || isNaN(uid)) {
+    return <div>Invalid ID.</div>;
+  }
+
+  // get the target unit from db
+  const [unit] = await db
+    .select()
+    .from(units)
+    .where(eq(units.id, uid));
+
+  // error for when unit doesn't exist
+  if (!unit) return <div>Unit not found.</div>;
+
+  // render the edit form and pass the unit data down to the client component
   return (
-    <div>{id}</div>
-  )
+    <div className="container mx-auto py-10">
+      <h1 className="text-3xl font-bold mb-6">Edit Unit</h1>
+      <EditUnitForm unit={unit} />
+    </div>
+  );
 }


### PR DESCRIPTION
## Why
We needed a feature for admins to edit course units (unit title)

## What
- Implemented edit unit page at: /admin/courses/[courseId]/units/edit/[unitId]
- Implemented database update logic in: src/actions/admin/unit.ts
- Built an edit form to autofill existing unit data and save changes w/ confirmation

## Satisfies
Closes (LRN-48) 
https://linear.app/acmutsa/issue/LRN-48