### PR TITLE
Add categories page with courses grouped by tags

### DIFF
--- a/src/app/categories/page.tsx
+++ b/src/app/categories/page.tsx
@@ -1,0 +1,39 @@
+// src/app/categories/page.tsx
+import { getCoursesGroupedByTag } from "@/lib/categories";
+import { CourseCard } from "@/components/client/course-card";
+
+export const metadata = {
+  title: "Categories | Learning with ACM",
+};
+
+export default async function CategoriesPage() {
+  const tags = await getCoursesGroupedByTag();
+
+  return (
+    <main className="mx-auto max-w-6xl px-6 py-10 space-y-10">
+      <header className="space-y-2">
+        <h1 className="text-3xl font-bold tracking-tight">Categories</h1>
+        <p className="text-sm text-slate-600">
+          Browse all courses grouped by category tags.
+        </p>
+      </header>
+
+      {tags.map((tag) => (
+        <section key={tag.id} className="space-y-3">
+          <h2 className="text-xl font-semibold">{tag.tagName}</h2>
+          <div className="flex flex-wrap gap-4">
+            {tag.courses.map((course) => (
+                <div key={course.id} className="w-full sm:w-[48%] lg:w-[45%]">
+                <CourseCard
+                    title={course.title}
+                    type="popular"
+                    tags={[tag.tagName]}
+                />
+                </div>
+            ))}
+          </div>
+        </section>
+      ))}
+    </main>
+  );
+}

--- a/src/lib/categories.ts
+++ b/src/lib/categories.ts
@@ -1,0 +1,68 @@
+import { eq } from "drizzle-orm";
+import { db } from "@/db"; 
+import { tags, courses, coursesTags, type Tag, type Course } from "@/db/schema";
+
+export type TagWithCourses = Tag & {
+  courses: Course[];
+};
+
+export async function getCoursesGroupedByTag(): Promise<TagWithCourses[]> {
+  const rows = await db
+    .select({
+      tagId: tags.id,
+      tagName: tags.tagName,
+      tagCreatedAt: tags.createdAt,
+      tagUpdatedAt: tags.updatedAt,
+      courseId: courses.id,
+      courseTitle: courses.title,
+      courseDescription: courses.description,
+      courseDifficulty: courses.difficulty,
+      courseCreatedBy: courses.createdBy,
+      courseCreatedAt: courses.createdAt,
+      courseUpdatedAt: courses.updatedAt,
+    })
+    .from(tags)
+    .leftJoin(coursesTags, eq(tags.id, coursesTags.tagId))
+    .leftJoin(courses, eq(coursesTags.courseId, courses.id));
+
+  const map = new Map<number, TagWithCourses>();
+
+  for (const row of rows) {
+    if (!row.tagId) continue;
+
+    let tag = map.get(row.tagId);
+    if (!tag) {
+        tag = {
+            id: row.tagId,
+            tagName: row.tagName,
+            createdBy: null, 
+            createdAt: row.tagCreatedAt,
+            updatedAt: row.tagUpdatedAt,
+            courses: [],
+        };
+        map.set(row.tagId, tag);
+    }
+
+    if (
+        row.courseId &&
+        row.courseTitle &&
+        row.courseDifficulty &&
+        row.courseCreatedAt &&
+        row.courseUpdatedAt
+    ) {
+        const course: Course = {
+        id: row.courseId,
+        title: row.courseTitle,
+        description: row.courseDescription, 
+        difficulty: row.courseDifficulty,
+        createdBy: row.courseCreatedBy,
+        createdAt: row.courseCreatedAt,
+        updatedAt: row.courseUpdatedAt,
+        };
+
+        tag.courses.push(course);
+    }
+}
+
+  return Array.from(map.values()).filter((t) => t.courses.length > 0);
+}


### PR DESCRIPTION
## Why 
Users need an easy way to browse courses by topic.

## What
Added a new /categories page that displays courses grouped by their tags.
Reused the existing CourseCard component for visual consistency.

## Satisfies
LRN-51
https://linear.app/acmutsa/issue/LRN-51

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new categories page that organizes and displays all available courses grouped by topic tags, improving discovery and navigation
  * Each category section presents courses in a responsive grid layout for seamless browsing
  * Users can now efficiently explore and filter the course catalog by their preferred subject areas

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->